### PR TITLE
Fixed non-functional documentation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ So I decided to to investigate if it is possible to achieve the following goals:
 - __concurrent__ handling of __multiple requests__.
 - Support for __Extensions__ to add additional functionality
 
-In my alternative design I try to split the processing up into many small pieces: So instead of sending a single big reply we can use the chunked http transfer encoding to feed many clients with small replys.  
+In my alternative design I try to split the processing up into many small pieces: So instead of sending a single big reply we can use the chunked http transfer encoding to feed many clients with small replies.  
 
 This should resolve also the memory restrictions for good because we do not have any upper totoal limit for the reply any more! 
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The basic HttpServer class just provides the functionality to
 - define rewrites
 - register reply handlers (callbacks)
 - register extensions
-- provide replys 
+- provide replies 
 - forward to URL
 - tunnel to URL
 

--- a/examples/httpForm/httpForm.ino
+++ b/examples/httpForm/httpForm.ino
@@ -35,7 +35,7 @@ const char* htmlForm =
                     <input type='range' id='clipThreashold' name='clipThreashold' \
                             onchange='this.form.submit()'\
                             min='0' max='6000' step='100' value='%clipThreashold%'>\
-                    <label for='clipThreashold'>Clip Threashold</label>\
+                    <label for='clipThreshold'>Clip Threshold</label>\
                 </div>\
                 <div>\
                     <input type='range' id='fuzzEffectValue' name='fuzzEffectValue' \

--- a/examples/webservice/webservice-html/webservice-html.ino
+++ b/examples/webservice/webservice-html/webservice-html.ino
@@ -75,7 +75,7 @@ const char* htmlForm =
                 <div>\
                     <input type='range' id='clipThreashold' name='clipThreashold' \
                             min='0' max='6000' step='100' value='0' onchange=\"$('#effect-form').submit();\">\
-                    <label for='clipThreashold'>Clip Threashold</label>\
+                    <label for='clipThreshold'>Clip Threshold</label>\
                 </div>\n\
                 <div>\
                     <input type='range' id='fuzzEffectValue' name='fuzzEffectValue' \


### PR DESCRIPTION
Adjusted spelling mistakes in a few locations.

### What’s fixed:
- `README.md`, line 14: `replys` → `replies`
- `README.md`, line 24: `replys` → `replies`
- `examples/httpForm/httpForm.ino`, line 38: `Threashold` → `Threshold`
- `examples/webservice/webservice-html/webservice-html.ino`, line 78: `Threashold` → `Threshold`

No code logic has been changed.